### PR TITLE
Gallery img fix

### DIFF
--- a/src/sass/_gallery.scss
+++ b/src/sass/_gallery.scss
@@ -91,6 +91,10 @@
   }
 }
 
+.gallery-photo {
+  object-fit: cover;
+}
+
 // .gallery {
 //   flex-wrap: wrap;
 //   display: flex;

--- a/src/sass/base/_base-styles.scss
+++ b/src/sass/base/_base-styles.scss
@@ -8,7 +8,6 @@ body.dark_mode {
 
 img {
   display: block;
-  height: 100%;
   max-width: 100%;
 }
 


### PR DESCRIPTION
- deleted height: 100% for element img in base-styles.scss
- added "object-fit" for element gallery-photo